### PR TITLE
Update getResumeData to work on github.io

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ class App extends Component {
 
   getResumeData(){
     $.ajax({
-      url:'/resumeData.json',
+      url: `${process.env.PUBLIC_URL}/resumeData.json`,
       dataType:'json',
       cache: false,
       success: function(data){
@@ -50,8 +50,8 @@ class App extends Component {
         this.setState({resumeData: data});
       }.bind(this),
       error: function(xhr, status, err){
-        console.log(err);
-        alert(err);
+        console.error(err);
+        // alert(err);
       }
     });
     // ref.on("value", function(snapshot) {


### PR DESCRIPTION
When the app is hosted on github.io it is hosted on a relative path with the repo's name

so in this case the call: `/resumeData.json` will not work, the solution I found is to use PUBLIC_URL, it'll be injected with the correct value on the build time by react-scripts